### PR TITLE
Line return conflict with trim rendering option

### DIFF
--- a/templates/bareos-dir/fileset/fileset.conf.j2
+++ b/templates/bareos-dir/fileset/fileset.conf.j2
@@ -10,13 +10,13 @@ FileSet {
 {% if item.options is defined %}
 {%- for option in item.options %}
     Options {
-{%- for data, suboption in option.items() -%}
+{% for data, suboption in option.items() -%}
 {% for line in suboption %}
       {{ line }}
-{%- endfor -%}
-{%- endfor %}
+{% endfor -%}
+{% endfor %}
     }
-{%- endfor %}
+{% endfor %}
 {% endif %}
     File = {{ item.include_file }}
   }


### PR DESCRIPTION
The trim rendering option seems activated in prod and messes with line returns when generating config files. This change prevents that.