### PR TITLE
Fix bareos repo, remove duplicate tasks

### DIFF
--- a/tasks/bareos_server.yml
+++ b/tasks/bareos_server.yml
@@ -76,14 +76,6 @@
     group: bareos
     mode: '0640'
 
-- name: Create bareos fd director config file
-  template:
-    src: bareos-fd/director/bareos-dir.conf.j2
-    dest: /etc/bareos/bareos-fd.d/director/bareos-dir.conf
-    owner: bareos
-    group: bareos
-    mode: '0640'
-
 - name: Create bareos fileset config files
   template:
     src: bareos-dir/fileset/fileset.conf.j2
@@ -162,15 +154,6 @@
     group: bareos
     mode: '0640'
   loop: "{{ bareos_jobs }}"
-
-- name: Create bareos client config files
-  template:
-    src: bareos-dir/client/client.conf.j2
-    dest: /etc/bareos/bareos-dir.d/client/{{ item.name }}.conf
-    owner: bareos
-    group: bareos
-    mode: '0640'
-  loop: "{{ bareos_clients }}"
 
 - name: Create bareos messages config files
   template:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,25 +17,25 @@
 
 - name: Add BareOS apt-key
   apt_key:
-    url: "http://download.bareos.org/bareos/release/{{ bareos_release }}/{{ bareos_os_version }}/Release.key"
+    url: "http://download.bareos.com/bareos/release/{{ bareos_release }}/{{ bareos_os_version }}/Release.key"
   when: ansible_os_family == 'Debian'
 
 - name: Ensure BareOS repo is present Debian
   apt_repository:
-    repo: "deb http://download.bareos.org/bareos/release/{{ bareos_release }}/{{ bareos_os_version }}/ /"
+    repo: "deb http://download.bareos.com/bareos/release/{{ bareos_release }}/{{ bareos_os_version }}/ /"
   when: ansible_os_family == 'Debian'
 
 - name: Import GPG key
   ansible.builtin.rpm_key:
     state: present
-    key: http://download.bareos.org/bareos/release/{{ bareos_release }}/{{ bareos_os_version }}/RPM-GPG-KEY
+    key: http://download.bareos.com/bareos/release/{{ bareos_release }}/{{ bareos_os_version }}/RPM-GPG-KEY
   when: ansible_os_family == 'RedHat'
 
 - name: Ensure BareOS repo is present RHEL
   ansible.builtin.yum_repository:
     name: bareos
     description: Bareos repo
-    baseurl: http://download.bareos.org/bareos/release/{{ bareos_release }}/{{ bareos_os_version }}/
+    baseurl: http://download.bareos.com/bareos/release/{{ bareos_release }}/{{ bareos_os_version }}/
   when: ansible_os_family == 'RedHat'
 
 - name: Install && setup bareos client

--- a/templates/bareos-dir-client.conf.j2
+++ b/templates/bareos-dir-client.conf.j2
@@ -1,0 +1,5 @@
+# {{ ansible_managed }}
+Director {
+  Name = bareos-dir
+  Password = "{{ bareos_client_password }}"
+}

--- a/templates/bareos-dir-client.conf.j2
+++ b/templates/bareos-dir-client.conf.j2
@@ -1,5 +1,0 @@
-# {{ ansible_managed }}
-Director {
-  Name = bareos-dir
-  Password = "{{ bareos_client_password }}"
-}

--- a/templates/bareos-dir/client/client.conf.j2
+++ b/templates/bareos-dir/client/client.conf.j2
@@ -1,7 +1,0 @@
-# {{ ansible_managed }}
-Client {
-  Name = {{ item.name }}
-  Address = "{{ item.address }}"
-  Password = "{{ bareos_client_password }}"
-  Maximum Concurrent Jobs = 50
-}

--- a/templates/bareos-fd/director/bareos-dir.conf.j2
+++ b/templates/bareos-fd/director/bareos-dir.conf.j2
@@ -1,5 +1,0 @@
-Director {
-  Name = bareos-dir
-  Password = "{{ bareos_client_password  }}"
-  Description = "Allow the configured Director to access this file daemon."
-}


### PR DESCRIPTION
[download.bareos.org](download.bareos.org) changed : 
"Bareos Community Repository
This repository contains the [bareos.org](https://www.bareos.org/) community builds. These binaries are UNSUPPORTED by [bareos.com](https://www.bareos.com/).
Get official binaries and vendor support on https://www.bareos.com/."

Playbook now fails with : 
`FAILED! => {"changed": false, "msg": "Failed to download key at http://download.bareos.org/bareos/release/[...]: HTTP Error 404: Not Found"}`

[download.bareos.com](download.bareos.com) is now the "Official Bareos Subscription Repository"

Also, remove duplicate tasks (and their templates) handled by register_client.yml