### PR TITLE
Add new parameter bareos_repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ __Note:__ More options can be seen in `defaults/main.yml`
 - `bareos_email` - Email address used for messages (Daemon, Standard) and Catalog bootstrap
 - `bareos_dir_ip_eth` - Director ethernet IP address
 - `bareos_director` - If you need to override backup director IP address on your client's /etc/hosts
+- `bareos_repo` - Defaults to Bareos Community Repository. Can be changed to use the Bareos Subscription Repository
 ```
 bareos_director:
   ip: 10.0.0.1

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,12 @@ bareos_db_package: postgresql-12
 bareos_install_client: false
 bareos_install_server: false
 bareos_register_clients: true
+
+# Defaults to Bareos Community Repository
+bareos_repo: "https://download.bareos.org/current/{{ bareos_os_version }}"
+# Bareos Subscription Repository
+# bareos_repo: "http://download.bareos.com/bareos/release/{{ bareos_release }}/{{ bareos_os_version }}"
+
 # Can be dangerous, use with care
 bareos_setup_db: false
 bareos_setup_db_sensu: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,25 +17,25 @@
 
 - name: Add BareOS apt-key
   apt_key:
-    url: "http://download.bareos.com/bareos/release/{{ bareos_release }}/{{ bareos_os_version }}/Release.key"
+    url: "{{ bareos_repo }}/Release.key"
   when: ansible_os_family == 'Debian'
 
 - name: Ensure BareOS repo is present Debian
   apt_repository:
-    repo: "deb http://download.bareos.com/bareos/release/{{ bareos_release }}/{{ bareos_os_version }}/ /"
+    repo: "deb {{ bareos_repo }}/ /"
   when: ansible_os_family == 'Debian'
 
 - name: Import GPG key
   ansible.builtin.rpm_key:
     state: present
-    key: http://download.bareos.com/bareos/release/{{ bareos_release }}/{{ bareos_os_version }}/RPM-GPG-KEY
+    key: {{ bareos_repo }}/RPM-GPG-KEY
   when: ansible_os_family == 'RedHat'
 
 - name: Ensure BareOS repo is present RHEL
   ansible.builtin.yum_repository:
     name: bareos
     description: Bareos repo
-    baseurl: http://download.bareos.com/bareos/release/{{ bareos_release }}/{{ bareos_os_version }}/
+    baseurl: {{ bareos_repo }}/
   when: ansible_os_family == 'RedHat'
 
 - name: Install && setup bareos client


### PR DESCRIPTION
Bareos now supports two repositories with different URLs:
 - Bareos Community Repository
 - Bareos Subscription Repository

The new variable defaults to the community repo.