### PR TITLE
feat: Mount block devices used as archive devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,17 @@ bareos_dir_storage:
 ```
 bareos_devices:
   - name: FileStorageFoo
-    arch_device: /backup
+    archive_device: /backup
+    block_device: /dev/mapper/backup    # optional
+    fstype: 'ext4'                      # default
+    mode: '0750'                        # default
+    opts: ''                            # optional, for ansible.posix.mount
+    state: 'mounted'                    # default, for ansible.posix.mount
 ```
+
+> [!WARNING]
+> The `bareos_devices[*].arch_device` is deprecated and replaced by
+> `bareos_devices[*].archive_device`.
 
 `bareos_schedules`: List of schedules in following format:
 

--- a/tasks/bareos_server.yml
+++ b/tasks/bareos_server.yml
@@ -121,6 +121,37 @@
   loop: "{{ bareos_dir_storage }}"
   when: bareos_dir_storage is defined
 
+- name: Configure Storage Daemon block devices
+  when: bareos_devices is defined
+  block:
+    - name: Create file systems
+      community.general.filesystem:
+        fstype: "{{ item.fstype | default('ext4') }}"
+        dev: "{{ item.block_device }}"
+        force: false
+        state: present
+      loop: "{{ bareos_devices }}"
+      # Create file system only when block_device starts with '/dev/'
+      when: item.block_device[:5] == '/dev/'
+
+    - name: Mount Bareos block devices
+      ansible.posix.mount:
+        path: "{{ item.archive_device | default(item.arch_device) }}"
+        src: "{{ item.block_device }}"
+        fstype: "{{ item.fstype | default('ext4') }}"
+        opts: "{{ item.opts | default(omit) }}"
+        state: "{{ item.state | default('mounted') }}"
+      loop: "{{ bareos_devices }}"
+
+    - name: Set permissions on archive devices
+      ansible.builtin.file:
+        path: "{{ item.archive_device | default(item.arch_device) }}"
+        owner: "bareos"
+        group: "bareos"
+        mode: "{{ item.mode | default('0750') }}"
+        state: directory
+      loop: "{{ bareos_devices }}"
+
 - name: Create bareos device config files
   template:
     src: bareos-sd/device/device.conf.j2

--- a/templates/bareos-sd/device/device.conf.j2
+++ b/templates/bareos-sd/device/device.conf.j2
@@ -2,7 +2,7 @@
 Device {
   Name = "{{ item.name }}"
   Media Type = File
-  Archive Device = {{ item.arch_device }}
+  Archive Device = {{ item.archive_device | default(item.arch_device) }}
   LabelMedia = yes;                   # lets Bareos label unlabeled media
   Random Access = yes;
   AutomaticMount = yes;               # when device opened, read it


### PR DESCRIPTION
Add a new block that allows to mount block devices to the path of the archive devices. Extend `block_device` to define the path of the block device.

Also deprecate `arch_device` in favor of `archive_device`.

Fixes #16