### PR TITLE
feat: Split Storage Daemon config from server

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -6,3 +6,8 @@
   service:
     name: apache2
     state: restarted
+
+- name: Restart bareos-storage
+  ansible.builtin.systemd:
+    name: bareos-storage.service
+    state: restarted

--- a/tasks/bareos_sd.yml
+++ b/tasks/bareos_sd.yml
@@ -33,7 +33,9 @@
         state: present
       loop: "{{ bareos_devices }}"
       # Create file system only when block_device starts with '/dev/'
-      when: item.block_device[:5] == '/dev/'
+      when:
+        - item.block_device is defined
+        - item.block_device[:5] == '/dev/'
 
     - name: Mount Bareos block devices
       ansible.posix.mount:
@@ -43,6 +45,7 @@
         opts: "{{ item.opts | default(omit) }}"
         state: "{{ item.state | default('mounted') }}"
       loop: "{{ bareos_devices }}"
+      when: item.block_device is defined
 
     - name: Set permissions on archive devices
       ansible.builtin.file:

--- a/tasks/bareos_sd.yml
+++ b/tasks/bareos_sd.yml
@@ -1,0 +1,65 @@
+---
+- name: Ensure bareos-storage is installed
+  ansible.builtin.apt:
+    name:
+      - bareos-storage
+
+- name: Configure Sd->Storage resource
+  template:
+    src: bareos-sd/storage/bareos-sd.conf.j2
+    dest: /etc/bareos/bareos-sd.d/storage/bareos-sd.conf
+    owner: bareos
+    group: bareos
+    mode: '0640'
+  notify: Restart bareos-storage
+
+- name: Configure Sd->Director resource
+  template:
+    src: bareos-sd/director/bareos-dir.conf.j2
+    dest: /etc/bareos/bareos-sd.d/director/bareos-dir.conf
+    owner: bareos
+    group: bareos
+    mode: '0640'
+  notify: Restart bareos-storage
+
+- name: Configure Storage Daemon block devices
+  when: bareos_devices is defined
+  block:
+    - name: Create file systems
+      community.general.filesystem:
+        fstype: "{{ item.fstype | default('ext4') }}"
+        dev: "{{ item.block_device }}"
+        force: false
+        state: present
+      loop: "{{ bareos_devices }}"
+      # Create file system only when block_device starts with '/dev/'
+      when: item.block_device[:5] == '/dev/'
+
+    - name: Mount Bareos block devices
+      ansible.posix.mount:
+        path: "{{ item.archive_device | default(item.arch_device) }}"
+        src: "{{ item.block_device }}"
+        fstype: "{{ item.fstype | default('ext4') }}"
+        opts: "{{ item.opts | default(omit) }}"
+        state: "{{ item.state | default('mounted') }}"
+      loop: "{{ bareos_devices }}"
+
+    - name: Set permissions on archive devices
+      ansible.builtin.file:
+        path: "{{ item.archive_device | default(item.arch_device) }}"
+        owner: "bareos"
+        group: "bareos"
+        mode: "{{ item.mode | default('0750') }}"
+        state: directory
+      loop: "{{ bareos_devices }}"
+
+- name: Configure Sd->Device resources
+  template:
+    src: bareos-sd/device/device.conf.j2
+    dest: /etc/bareos/bareos-sd.d/device/{{ item.name }}.conf
+    owner: bareos
+    group: bareos
+    mode: '0640'
+  loop: "{{ bareos_devices }}"
+  when: bareos_devices is defined
+  notify: Restart bareos-storage

--- a/tasks/bareos_server.yml
+++ b/tasks/bareos_server.yml
@@ -83,14 +83,6 @@
     group: bareos
     mode: '0640'
 
-- name: Create bareos sd director config file
-  template:
-    src: bareos-sd/director/bareos-dir.conf.j2
-    dest: /etc/bareos/bareos-sd.d/director/bareos-dir.conf
-    owner: bareos
-    group: bareos
-    mode: '0640'
-
 - name: Create bareos fileset config files
   template:
     src: bareos-dir/fileset/fileset.conf.j2
@@ -120,55 +112,6 @@
     mode: '0640'
   loop: "{{ bareos_dir_storage }}"
   when: bareos_dir_storage is defined
-
-- name: Configure Storage Daemon block devices
-  when: bareos_devices is defined
-  block:
-    - name: Create file systems
-      community.general.filesystem:
-        fstype: "{{ item.fstype | default('ext4') }}"
-        dev: "{{ item.block_device }}"
-        force: false
-        state: present
-      loop: "{{ bareos_devices }}"
-      # Create file system only when block_device starts with '/dev/'
-      when: item.block_device[:5] == '/dev/'
-
-    - name: Mount Bareos block devices
-      ansible.posix.mount:
-        path: "{{ item.archive_device | default(item.arch_device) }}"
-        src: "{{ item.block_device }}"
-        fstype: "{{ item.fstype | default('ext4') }}"
-        opts: "{{ item.opts | default(omit) }}"
-        state: "{{ item.state | default('mounted') }}"
-      loop: "{{ bareos_devices }}"
-
-    - name: Set permissions on archive devices
-      ansible.builtin.file:
-        path: "{{ item.archive_device | default(item.arch_device) }}"
-        owner: "bareos"
-        group: "bareos"
-        mode: "{{ item.mode | default('0750') }}"
-        state: directory
-      loop: "{{ bareos_devices }}"
-
-- name: Create bareos device config files
-  template:
-    src: bareos-sd/device/device.conf.j2
-    dest: /etc/bareos/bareos-sd.d/device/{{ item.name }}.conf
-    owner: bareos
-    group: bareos
-    mode: '0640'
-  loop: "{{ bareos_devices }}"
-  when: bareos_devices is defined
-
-- name: Create bareos sd storage config file
-  template:
-    src: bareos-sd/storage/bareos-sd.conf.j2
-    dest: /etc/bareos/bareos-sd.d/storage/bareos-sd.conf
-    owner: bareos
-    group: bareos
-    mode: '0640'
 
 - name: Create bareos schedule config files
   template:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -46,6 +46,10 @@
   include_tasks: bareos_server.yml
   when: bareos_install_server
 
+- name: Install Bareos Storage Daemon
+  include_tasks: bareos_sd.yml
+  when: "'bareos_storage' in group_names or bareos_install_server"
+
 - name: Register clients
   include_tasks: register_client.yml
   with_items: "{{ bareos_clients }}"

--- a/templates/bareos-sd/storage/bareos-sd.conf.j2
+++ b/templates/bareos-sd/storage/bareos-sd.conf.j2
@@ -1,5 +1,5 @@
 Storage {
-  Name = bareos-sd
+  Name = {{ inventory_hostname }}-sd
   Maximum Concurrent Jobs = 50
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.


### PR DESCRIPTION
Move the tasks that configure the Storage Daemon from the bareos_server
file to a dedicated tasks file. Include this file for hosts member of
the group `bareos_storage`.
    
Also include the file when `bareos_install_server` is true for backward
compatibility.