### PR TITLE
fix: Allow to define Dir->JobDefs Type

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ bareos_jobdefs:
     pool: IncrementalFoo
     full_pool: FullFoo
     incr_pool: IncrementalFoo
+    type: JOB_TYPE                      # optional, defaults to 'Backup'
 ```
 
 `bareos_jobs`: List of jobs in following format:

--- a/templates/bareos-dir/jobdefs/jobdef.conf.j2
+++ b/templates/bareos-dir/jobdefs/jobdef.conf.j2
@@ -1,7 +1,7 @@
 # {{ ansible_managed }}
 JobDefs {
   Name = "{{ item.name }}"
-  Type = Backup
+  Type = {{ item.type | default('Backup') }}
   Level = {{ item.level }}
   Client = {{ item.client }}
   FileSet = "{{ item.fileset }}"


### PR DESCRIPTION
Do not enforce the Backup JOB_TYPE in the template, users must be able to configure different types of jobs.