### PR TITLE
fix: Make Volume Retention (Dir->Pool) optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ bareos_filesets:
 ```
 bareos_pools:
   - name: FullFoo
-    retention: "365 days"
+    retention: "365 days"               # optional
     max_vol_bytes: 50G                  # optional
     max_vol: 1000                       # optional
     next_pool: FullFooOffsite           # optional

--- a/templates/bareos-dir/pool/pool.conf.j2
+++ b/templates/bareos-dir/pool/pool.conf.j2
@@ -4,7 +4,9 @@ Pool {
   Pool Type = Backup
   Recycle = yes
   AutoPrune = yes
+{% if item.retention is defined %}
   Volume Retention = {{ item.retention }}
+{% endif %}
 {% if item.max_vol_bytes is defined %}
   Maximum Volume Bytes = {{ item.max_vol_bytes }}
 {% endif %}


### PR DESCRIPTION
This parameter is not required in the Pool resource configuration, thus it must be optional.