### PR TITLE
fix: Use a single template for Job and JobDefs

### DIFF
--- a/tasks/bareos_server.yml
+++ b/tasks/bareos_server.yml
@@ -124,6 +124,8 @@
   when: bareos_schedules is defined
 
 - name: Create bareos jobdef config files
+  vars:
+    _resource_type: 'JobDefs'
   template:
     src: bareos-dir/jobdefs/jobdef.conf.j2
     dest: /etc/bareos/bareos-dir.d/jobdefs/{{ item.name }}.conf
@@ -142,6 +144,8 @@
     mode: '0640'
 
 - name: Create bareos job config files
+  vars:
+    _resource_type: 'Job'
   template:
     src: bareos-dir/job/job.conf.j2
     dest: /etc/bareos/bareos-dir.d/job/{{ item.name }}.conf

--- a/templates/bareos-dir/job/job.conf.j2
+++ b/templates/bareos-dir/job/job.conf.j2
@@ -1,8 +1,1 @@
-# {{ ansible_managed }}
-Job {
-  Name = "{{ item.name }}"
-  JobDefs = "{{ item.jobdef }}"
-  Client = "{{ item.client }}"
-  Maximum Concurrent Jobs = 50
-  Allow Duplicate Jobs = no
-}
+../jobdefs/jobdef.conf.j2

--- a/templates/bareos-dir/jobdefs/jobdef.conf.j2
+++ b/templates/bareos-dir/jobdefs/jobdef.conf.j2
@@ -1,23 +1,75 @@
 # {{ ansible_managed }}
-JobDefs {
+{#
+This template is used for both Job and JobDefs resource types.
+Keep the legacy defaults when the template is used to define JobDefs resources
+#}
+{{ _resource_type }} {
   Name = "{{ item.name }}"
-  Type = {{ item.type | default('Backup') }}
+{% if _resource_type == 'Job' and item.jobdef is defined %}
+  JobDefs = "{{ item.jobdef }}"
+{% endif %}
+{% if item.type is defined %}
+  Type = {{ item.type }}
+{% elif _resource_type == 'JobDefs' %}
+  Type = Backup
+{% endif %}
+{% if item.level is defined %}
   Level = {{ item.level }}
+{% endif %}
+{% if item.client is defined %}
   Client = {{ item.client }}
+{% endif %}
+{% if item.fileset is defined %}
   FileSet = "{{ item.fileset }}"
+{% endif %}
+{% if item.schedule is defined %}
   Schedule = "{{ item.schedule }}"
+{% endif %}
 {% if item.storage is defined %}
   Storage = {{ item.storage }}
 {% endif %}
+{% if item.messages is defined %}
+  Messages = {{ item.messages }}
+{% elif _resource_type == 'JobDefs' %}
   Messages = Standard
+{% endif %}
+{% if item.pool is defined %}
   Pool = {{ item.pool }}
-  Priority = {{ item.priority | default('10') }}
+{% endif %}
+{% if item.priority is defined %}
+  Priority = {{ item.priority }}
+{% elif _resource_type == 'JobDefs' %}
+  Priority = 10
+{% endif %}
+{% if item.write_bootstrap is defined %}
+  Write Bootstrap = "{{ item.write_bootstrap }}"
+{% elif _resource_type == 'JobDefs' %}
   Write Bootstrap = "/var/lib/bareos/%c.bsr"
+{% endif %}
+{% if item.full_pool is defined %}
   Full Backup Pool = {{ item.full_pool }}
+{% endif %}
 {% if item.incr_pool is defined %}
   Incremental Backup Pool = {{ item.incr_pool }}
 {% endif %}
+{% if item.max_concurrent_jobs is defined %}
+  Maximum Concurrent Jobs = {{ item.max_concurrent_jobs }}
+{% elif _resource_type == 'JobDefs' %}
+  Maximum Concurrent Jobs = 50
+{% endif %}
+{% if item.allow_dup_jobs is defined %}
+  Allow Duplicate Jobs = {{ item.allow_dup_jobs }}
+{% elif _resource_type == 'JobDefs' %}
   Allow Duplicate Jobs = no
+{% endif %}
+{% if item.cancel_lower_level_dup is defined %}
+  Cancel Lower Level Duplicates = {{ item.cancel_lower_level_dup }}
+{% elif _resource_type == 'JobDefs' %}
   Cancel Lower Level Duplicates = yes
+{% endif %}
+{% if item.cancel_queued_dup is defined %}
+  Cancel Queued Duplicates = {{ item.cancel_queued_dup }}
+{% elif _resource_type == 'JobDefs' %}
   Cancel Queued Duplicates = yes
+{% endif %}
 }


### PR DESCRIPTION
Since Job and JobDefs resources share the same directives, use a single Jinja2 template. The resource type is declared with an internal variable `_resource_type` defined for the template tasks.

For readibility of the role, use a symlink job.conf.j2 -> jobdef.conf.j2

Some default values were defined in the JobDefs templates. Keep these defaults for JobDefs resources if not defined.

Fixes: #28