### PR TITLE
feat: Allow to include multiple File path

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,21 @@ bareos_clients:
 bareos_filesets:
   - name: FilesetFoo
     description: "Backup Foo"
-    include_file: /home/foo
-    exclude_file:
+    include_files:
+      - /home/foo
+    exclude_files:
       - /home/foo/bar
 ```
+
+> [!WARNING]
+> The `bareos_filesets[*].include_file` is deprecated and replaced by
+> `bareos_filesets[*].include_files` that allows to define a list of File path
+> to include.
+
+> [!WARNING]
+> The `bareos_filesets[*].exclude_file` is deprecated and replaced by
+> `bareos_filesets[*].exclude_files` to reflect the ability to exclude a list
+> of File path.
 
 - `bareos_pools`: List of pools in following format:
 

--- a/templates/bareos-dir/fileset/fileset.conf.j2
+++ b/templates/bareos-dir/fileset/fileset.conf.j2
@@ -18,7 +18,14 @@ FileSet {
     }
 {% endfor %}
 {% endif %}
+{% if item.include_files is defined %}
+{% for include_file in item.include_files %}
+    File = {{ include_file }}
+{% endfor %}
+{# item.include_file is deprecated #}
+{% else %}
     File = {{ item.include_file }}
+{% endif %}
   }
   # Things that usually have to be excluded
   # You have to exclude /var/lib/bareos/storage
@@ -27,9 +34,15 @@ FileSet {
 {% for file in bareos_excludes %}
     File = {{ file }}
 {% endfor %}
+{% if item.exclude_files is defined %}
+{% for exclude_file in item.exclude_files %}
+    File = {{ exclude_file }}
+{% endfor %}
+{% endif %}
+{# item.exclude_file is deprecated #}
 {% if item.exclude_file is defined %}
-{% for line in item.exclude_file %}
-    File = {{ line }}
+{% for exclude_file in item.exclude_file %}
+    File = {{ exclude_file }}
 {% endfor %}
 {% endif %}
   }


### PR DESCRIPTION
A FileSet resource could be configured with multiple File parameters. Add a new variable `include_files` to the items of `bareos_filesets` to loop over of list to define `File`.

Use plural form for include and exclude lists.

Deprecate old variables to prepare removal in a future release.