### PR TITLE
Add Bareos 23 capability, templates upgrades, fixes

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         distro:
-          - debian-systemd:bullseye
+          - debian-systemd:bookworm
 
     env:
       MOLECULE_DISTRO: ${{ matrix.distro }}

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ bareos_pools:
 bareos_dir_storage:
   - name: FileFoo
     device: FileStorageFoo
-    bareos_dir_ip: 10.0.0.1
+    bareos_sd_ip: 10.0.0.1
     media_type: File2                   # optional, defaults to 'File'
     max_concurrent_jobs: 42             # optional, defaults to '50'
 ```
@@ -97,7 +97,7 @@ bareos_dir_storage:
     devices:
         - FileStorageFoo
         - FileStorageBar
-    bareos_dir_ip: 10.0.0.1
+    bareos_sd_ip: 10.0.0.1
     media_type: File2                   # optional, defaults to 'File'
     max_concurrent_jobs: 42             # optional, defaults to '50'
 ```
@@ -159,7 +159,6 @@ __NOTES:__
 
 - `ansible_delegate_hostname` must match `inventory_hostname` in ansible inventory list.
 Some tasks will be delegated from backup server to this client
-- `enable_backup_job` - Will create backup job `DefaultJobLinux`
 - `state` - When set to `absent`, client will be removed from server config (default: `present`)
 - `autostart` - Schedule first backup right away (default: `true`)
 - `director_ip` - [Optional] Same as `bareos_director`, just different place to setup

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ bareos_clients:
     password: MySuperSecretPassword
     enable_backup_job: true
     state: present                      # optional
+    autostart: true                     # optional
     director_ip: 10.0.0.1               # optional
     director_name: backup               # optional
     max_job_bandwidth: 1 mb/s           # optional
@@ -159,7 +160,9 @@ __NOTES:__
 
 - `ansible_delegate_hostname` must match `inventory_hostname` in ansible inventory list.
 Some tasks will be delegated from backup server to this client
+- `enable_backup_job` - Will create backup job `DefaultJobLinux`
 - `state` - When set to `absent`, client will be removed from server config (default: `present`)
+- `autostart` - Schedule first backup right away (default: `false`)
 - `director_ip` - [Optional] Same as `bareos_director`, just different place to setup
 - `director_name` - [Optional] Same as `bareos_director`, just different place to setup
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ __Note:__ More options can be seen in `defaults/main.yml`
 - `bareos_director` - If you need to override backup director IP address on your client's /etc/hosts
 - `bareos_repo` - Defaults to Bareos Community Repository. Can be changed to use the Bareos Subscription Repository
 - `bareos_sd_max_concurrent_jobs` - [Optional] SD-level maximum concurrent jobs, defaults to 50
+- `bareos_catalog_backup_script` - You need to set it to `/usr/lib/bareos/scripts/make_catalog_backup` if using Bareos >=23
 ```
 bareos_director:
   ip: 10.0.0.1
@@ -32,7 +33,6 @@ bareos_clients:
     password: MySuperSecretPassword
     enable_backup_job: true
     state: present                      # optional
-    autostart: true                     # optional
     director_ip: 10.0.0.1               # optional
     director_name: backup               # optional
     max_job_bandwidth: 1 mb/s           # optional
@@ -160,7 +160,6 @@ __NOTES:__
 - `ansible_delegate_hostname` must match `inventory_hostname` in ansible inventory list.
 Some tasks will be delegated from backup server to this client
 - `state` - When set to `absent`, client will be removed from server config (default: `present`)
-- `autostart` - Schedule first backup right away (default: `true`)
 - `director_ip` - [Optional] Same as `bareos_director`, just different place to setup
 - `director_name` - [Optional] Same as `bareos_director`, just different place to setup
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
-bareos_release: 21
-bareos_db_package: postgresql-12
+bareos_release: 23
+bareos_db_package: postgresql-15
 bareos_install_client: false
 bareos_install_server: false
 bareos_register_clients: true
@@ -37,3 +37,4 @@ bareos_apt_monitoring_packages:
   - python3-psycopg2
   - python3-mysqldb
   - gpg
+bareos_catalog_backup_script: /usr/lib/bareos/scripts/make_catalog_backup.pl

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,8 @@ bareos_email: 'root@localhost'
 
 # Defaults to Bareos Community Repository
 bareos_repo: "https://download.bareos.org/current/{{ bareos_os_version }}"
+bareos_repo_key: "{{ bareos_repo }}/Release.key"
+bareos_repository: "deb {{ bareos_repo }}/ /"
 # Bareos Subscription Repository
 # bareos_repo: "http://download.bareos.com/bareos/release/{{ bareos_release }}/{{ bareos_os_version }}"
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
   namespace: mila
   description: Role for managing bareos server & clients
   license: MIT
-  min_ansible_version: '2.14'
+  min_ansible_version: '2.16'
   platforms:
     - name: Debian
       versions:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -5,14 +5,14 @@ driver:
   name: docker
 platforms:
   - name: server
-    image: "quay.io/actatux/${MOLECULE_DISTRO:-debian-systemd:bullseye}"
+    image: "quay.io/actatux/${MOLECULE_DISTRO:-debian-systemd:bookworm}"
     override_command: false
     privileged: true
     pre_build_image: true
     groups:
       - servers
   - name: client
-    image: "quay.io/actatux/${MOLECULE_DISTRO:-debian-systemd:bullseye}"
+    image: "quay.io/actatux/${MOLECULE_DISTRO:-debian-systemd:bookworm}"
     override_command: false
     privileged: true
     pre_build_image: true

--- a/tasks/bareos_server.yml
+++ b/tasks/bareos_server.yml
@@ -37,7 +37,7 @@
       ansible.builtin.file:
         path: "/etc/bareos/bareos-dir.d/"
         state: directory
-        recurse: yes
+        recurse: true
         group: postgres
       changed_when: false
 
@@ -62,7 +62,7 @@
       ansible.builtin.file:
         path: "/etc/bareos/bareos-dir.d/"
         state: directory
-        recurse: yes
+        recurse: true
         group: bareos
       changed_when: false
 

--- a/tasks/bareos_server.yml
+++ b/tasks/bareos_server.yml
@@ -33,6 +33,14 @@
 - name: Setup bareos DB
   when: bareos_setup_db
   block:
+    - name: Recursively change bareos-dir directory ownership group to postgres
+      ansible.builtin.file:
+        path: "/etc/bareos/bareos-dir.d/"
+        state: directory
+        recurse: yes
+        group: postgres
+      changed_when: false
+
     - name: Check that bareos DB exists
       shell: psql -lqt | cut -d \| -f 1 | grep -qw bareos
       become: true
@@ -49,6 +57,14 @@
         /usr/lib/bareos/scripts/make_bareos_tables &&
         /usr/lib/bareos/scripts/grant_bareos_privileges
       when: _bareos_db_exists.rc != 0
+
+    - name: Recursively change bareos-dir directory ownership group to bareos
+      ansible.builtin.file:
+        path: "/etc/bareos/bareos-dir.d/"
+        state: directory
+        recurse: yes
+        group: bareos
+      changed_when: false
 
 - name: Setup bareos DB monitoring
   when: bareos_setup_db_sensu

--- a/tasks/bareos_server.yml
+++ b/tasks/bareos_server.yml
@@ -13,12 +13,6 @@
     line: '  dbpassword = "{{ bareos_postgres_pass }}"'
   when: bareos_postgres_pass is defined
 
-- name: Remove dbaddress from catalog configuration
-  ansible.builtin.lineinfile:
-    path: /etc/bareos/bareos-dir.d/catalog/MyCatalog.conf
-    regexp: '^  dbaddress ='
-    state: absent
-
 - name: Ensure bareos postgresql is installed
   apt:
     name: bareos-database-postgresql

--- a/tasks/bareos_server.yml
+++ b/tasks/bareos_server.yml
@@ -117,18 +117,6 @@
   loop: "{{ bareos_schedules }}"
   when: bareos_schedules is defined
 
-- name: Create bareos jobdef config files
-  vars:
-    _resource_type: 'JobDefs'
-  template:
-    src: bareos-dir/jobdefs/jobdef.conf.j2
-    dest: /etc/bareos/bareos-dir.d/jobdefs/{{ item.name }}.conf
-    owner: bareos
-    group: bareos
-    mode: '0640'
-  loop: "{{ bareos_jobdefs }}"
-  when: bareos_jobdefs is defined
-
 - name: Create bareos catalog job config file
   template:
     src: bareos-dir/job/BackupCatalog.conf.j2
@@ -136,18 +124,6 @@
     owner: bareos
     group: bareos
     mode: '0640'
-
-- name: Create bareos job config files
-  vars:
-    _resource_type: 'Job'
-  template:
-    src: bareos-dir/job/job.conf.j2
-    dest: /etc/bareos/bareos-dir.d/job/{{ item.name }}.conf
-    owner: bareos
-    group: bareos
-    mode: '0640'
-  loop: "{{ bareos_jobs }}"
-  when: bareos_jobs is defined
 
 - name: Create bareos messages config files
   template:

--- a/tasks/bareos_server.yml
+++ b/tasks/bareos_server.yml
@@ -117,6 +117,18 @@
   loop: "{{ bareos_schedules }}"
   when: bareos_schedules is defined
 
+- name: Create bareos jobdef config files
+  vars:
+    _resource_type: 'JobDefs'
+  template:
+    src: bareos-dir/jobdefs/jobdef.conf.j2
+    dest: /etc/bareos/bareos-dir.d/jobdefs/{{ item.name }}.conf
+    owner: bareos
+    group: bareos
+    mode: '0640'
+  loop: "{{ bareos_jobdefs }}"
+  when: bareos_jobdefs is defined
+
 - name: Create bareos catalog job config file
   template:
     src: bareos-dir/job/BackupCatalog.conf.j2
@@ -124,6 +136,18 @@
     owner: bareos
     group: bareos
     mode: '0640'
+
+- name: Create bareos job config files
+  vars:
+    _resource_type: 'Job'
+  template:
+    src: bareos-dir/job/job.conf.j2
+    dest: /etc/bareos/bareos-dir.d/job/{{ item.name }}.conf
+    owner: bareos
+    group: bareos
+    mode: '0640'
+  loop: "{{ bareos_jobs }}"
+  when: bareos_jobs is defined
 
 - name: Create bareos messages config files
   template:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,12 +17,12 @@
 
 - name: Add BareOS apt-key
   apt_key:
-    url: "{{ bareos_repo }}/Release.key"
+    url: "{{ bareos_repo_key }}"
   when: ansible_os_family == 'Debian'
 
 - name: Ensure BareOS repo is present Debian
-  apt_repository:
-    repo: "deb {{ bareos_repo }}/ /"
+  ansible.builtin.apt_repository:
+    repo: "{{ bareos_repository }}"
   when: ansible_os_family == 'Debian'
 
 - name: Import GPG key

--- a/tasks/register_client.yml
+++ b/tasks/register_client.yml
@@ -81,14 +81,31 @@
     ( 'Failed' in _bconsole_output.stdout )
   changed_when: false
 
-- name: Add backup job
+- name: Create bareos jobdef config files
+  vars:
+    _resource_type: 'JobDefs'
   template:
-    src: backup-job.conf.j2
-    dest: "/etc/bareos/bareos-dir.d/job/backup-{{ item.name }}.conf"
-    mode: 0640
+    src: bareos-dir/jobdefs/jobdef.conf.j2
+    dest: /etc/bareos/bareos-dir.d/jobdefs/{{ item.name }}.conf
     owner: bareos
     group: bareos
-  when: item.enable_backup_job
+    mode: '0640'
+  loop: "{{ bareos_jobdefs }}"
+  when: bareos_jobdefs is defined
+  register: _bareos_backup_job
+  notify: Reload bareos server
+
+- name: Create bareos job config files
+  vars:
+    _resource_type: 'Job'
+  template:
+    src: bareos-dir/job/job.conf.j2
+    dest: /etc/bareos/bareos-dir.d/job/{{ item.name }}.conf
+    owner: bareos
+    group: bareos
+    mode: '0640'
+  loop: "{{ bareos_jobs }}"
+  when: bareos_jobs is defined
   register: _bareos_backup_job
   notify: Reload bareos server
 

--- a/tasks/register_client.yml
+++ b/tasks/register_client.yml
@@ -81,36 +81,30 @@
     ( 'Failed' in _bconsole_output.stdout )
   changed_when: false
 
-- name: Create bareos jobdef config files
-  vars:
-    _resource_type: 'JobDefs'
+- name: Add backup job
   template:
-    src: bareos-dir/jobdefs/jobdef.conf.j2
-    dest: /etc/bareos/bareos-dir.d/jobdefs/{{ item.name }}.conf
+    src: backup-job.conf.j2
+    dest: "/etc/bareos/bareos-dir.d/job/backup-{{ item.name }}.conf"
+    mode: 0640
     owner: bareos
     group: bareos
-    mode: '0640'
-  loop: "{{ bareos_jobdefs }}"
-  when: bareos_jobdefs is defined
-  register: _bareos_backup_job
-  notify: Reload bareos server
-
-- name: Create bareos job config files
-  vars:
-    _resource_type: 'Job'
-  template:
-    src: bareos-dir/job/job.conf.j2
-    dest: /etc/bareos/bareos-dir.d/job/{{ item.name }}.conf
-    owner: bareos
-    group: bareos
-    mode: '0640'
-  loop: "{{ bareos_jobs }}"
-  when: bareos_jobs is defined
+  when: item.enable_backup_job
   register: _bareos_backup_job
   notify: Reload bareos server
 
 - name: Flush handlers, to make sure bareos is reloaded
   meta: flush_handlers
+
+- name: Start first backup
+  shell: >
+    echo
+    "run job=backup-{{ item.name }} client={{ item.name }} yes"
+    | bconsole
+  register: _bconsole_output
+  failed_when: ('Error' in _bconsole_output.stdout) or ('Failed' in _bconsole_output.stdout) or ('not found' in _bconsole_output.stdout)
+  when:
+    - item.autostart | default(false)
+    - _bareos_backup_job.changed
 
 - name: Update client address if changed
   lineinfile:

--- a/tasks/register_client.yml
+++ b/tasks/register_client.yml
@@ -112,17 +112,6 @@
 - name: Flush handlers, to make sure bareos is reloaded
   meta: flush_handlers
 
-- name: Start first backup
-  shell: >
-    echo
-    "run job=backup-{{ item.name }} client={{ item.name }} yes"
-    | bconsole
-  register: _bconsole_output
-  failed_when: ('Error' in _bconsole_output.stdout) or ('Failed' in _bconsole_output.stdout) or ('not found' in _bconsole_output.stdout)
-  when:
-    - item.autostart | default(true)
-    - _bareos_backup_job.changed
-
 - name: Update client address if changed
   lineinfile:
     path: /etc/bareos/bareos-dir.d/client/{{ item.name }}.conf

--- a/templates/bareos-dir/job/BackupCatalog.conf.j2
+++ b/templates/bareos-dir/job/BackupCatalog.conf.j2
@@ -7,9 +7,9 @@ Job {
   Schedule = "WeeklyCycleAfterBackup"
 
   # This creates an ASCII copy of the catalog
-  # Arguments to make_catalog_backup.pl are:
-  #  make_catalog_backup.pl <catalog-name>
-  RunBeforeJob = "/usr/lib/bareos/scripts/make_catalog_backup.pl MyCatalog"
+  # Arguments to make_catalog_backup are:
+  #  make_catalog_backup <catalog-name>
+  RunBeforeJob = "{{ bareos_catalog_backup_script }} MyCatalog"
 
   # This deletes the copy of the catalog
   RunAfterJob  = "/usr/lib/bareos/scripts/delete_catalog_backup"

--- a/templates/bareos-dir/jobdefs/jobdef.conf.j2
+++ b/templates/bareos-dir/jobdefs/jobdef.conf.j2
@@ -78,4 +78,7 @@ Keep the legacy defaults when the template is used to define JobDefs resources
 {% if item.spool_data is defined %}
   Spool Data = {{ item.spool_data }}
 {% endif %}
+{% if item.enabled is defined %}
+  Enabled = {{ item.enabled }}
+{% endif %}
 }

--- a/templates/bareos-dir/jobdefs/jobdef.conf.j2
+++ b/templates/bareos-dir/jobdefs/jobdef.conf.j2
@@ -72,4 +72,10 @@ Keep the legacy defaults when the template is used to define JobDefs resources
 {% elif _resource_type == 'JobDefs' %}
   Cancel Queued Duplicates = yes
 {% endif %}
+{% if item.selection_type is defined %}
+  Selection Type = {{ item.selection_type }}
+{% endif %}
+{% if item.spool_data is defined %}
+  Spool Data = {{ item.spool_data }}
+{% endif %}
 }

--- a/templates/bareos-dir/storage/storage.conf.j2
+++ b/templates/bareos-dir/storage/storage.conf.j2
@@ -1,7 +1,7 @@
 # {{ ansible_managed }}
 Storage {
   Name = "{{ item.name }}"
-  Address = "{{ item.bareos_dir_ip }}"
+  Address = "{{ item.bareos_sd_ip }}"
   Password = "{{ bareos_storage_password }}"
   Media Type = {{ item.media_type | default('File') }}
 {% if item.devices is defined %}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = ansible{8,9}
+envlist = ansible{9,10}
 skipsdist = true
 
 [testenv]
@@ -11,8 +11,8 @@ passenv =
     PY_COLORS
     ANSIBLE_FORCE_COLOR
 deps =
-    ansible8: ansible>=8.0,<9.0
     ansible9: ansible>=9.0,<10.0
+    ansible10: ansible>=10.0,<11.0
     molecule
     molecule-plugins[docker]
 commands =

--- a/vars/Debian12.yml
+++ b/vars/Debian12.yml
@@ -2,6 +2,6 @@
 bareos_os_version: Debian_12
 bareos_db_package: postgresql-15
 _bareos_support_packages:
+  - acl
   - gpg
   - gpgv2
-  - acl

--- a/vars/Debian12.yml
+++ b/vars/Debian12.yml
@@ -4,3 +4,4 @@ bareos_db_package: postgresql-15
 _bareos_support_packages:
   - gpg
   - gpgv2
+  - acl


### PR DESCRIPTION
- Add possibility to use other repos (e.g your own mirror)
- Add missing `acl` package for Debian 12
- Rename `bareos_dir_ip` to `bareos_sd_ip` (as it was a typo from the beginning, it's always been the sd ip)
- Do not remove `dbaddress` from the catalog config, initial install will fail
- Handle rename catalog backup script (>= Bareos 23)
- Add Selection Type, Spool Data and Enabled vars for jobs/jobdefs

Breaking changes : 
  - `bareos_dir_ip` becomes `bareos_sd_ip`
  - Change default of `autostart` to false