### PR TITLE
Register clients with a template instead of shell/bconsole

### DIFF
--- a/tasks/bareos_server.yml
+++ b/tasks/bareos_server.yml
@@ -92,6 +92,7 @@
     owner: bareos
     group: bareos
     mode: '0640'
+  notify: Reload bareos server
 
 - name: Create bareos fileset config files
   template:
@@ -102,6 +103,7 @@
     mode: '0640'
   loop: "{{ bareos_filesets }}"
   when: bareos_filesets is defined
+  notify: Reload bareos server
 
 - name: Create bareos pool config files
   template:
@@ -112,6 +114,7 @@
     mode: '0640'
   loop: "{{ bareos_pools }}"
   when: bareos_pools is defined
+  notify: Reload bareos server
 
 - name: Create bareos dir storage config files
   template:
@@ -122,6 +125,7 @@
     mode: '0640'
   loop: "{{ bareos_dir_storage }}"
   when: bareos_dir_storage is defined
+  notify: Reload bareos server
 
 - name: Create bareos schedule config files
   template:
@@ -132,6 +136,7 @@
     mode: '0640'
   loop: "{{ bareos_schedules }}"
   when: bareos_schedules is defined
+  notify: Reload bareos server
 
 - name: Create bareos jobdef config files
   vars:
@@ -144,6 +149,7 @@
     mode: '0640'
   loop: "{{ bareos_jobdefs }}"
   when: bareos_jobdefs is defined
+  notify: Reload bareos server
 
 - name: Create bareos catalog job config file
   template:
@@ -152,6 +158,7 @@
     owner: bareos
     group: bareos
     mode: '0640'
+  notify: Reload bareos server
 
 - name: Create bareos job config files
   vars:
@@ -164,6 +171,7 @@
     mode: '0640'
   loop: "{{ bareos_jobs }}"
   when: bareos_jobs is defined
+  notify: Reload bareos server
 
 - name: Create bareos messages config files
   template:
@@ -175,6 +183,7 @@
   loop:
     - { src: 'bareos-dir/messages/Daemon.conf.j2', dest: '/etc/bareos/bareos-dir.d/messages/Daemon.conf' }
     - { src: 'bareos-dir/messages/Standard.conf.j2', dest: '/etc/bareos/bareos-dir.d/messages/Standard.conf' }
+  notify: Reload bareos server
 
 - name: Add bconsole config file
   template:
@@ -183,6 +192,7 @@
     mode: 0700
     owner: bareos
     group: bareos
+  notify: Reload bareos server
 
 - name: Add webui admin console
   template:

--- a/tasks/register_client.yml
+++ b/tasks/register_client.yml
@@ -1,5 +1,5 @@
 ---
-- name: Create client {{ item.name }} config file
+- name: Create client config file for {{ item.name }}
   template:
     src: bareos-dir/client/client.conf.j2
     dest: /etc/bareos/bareos-dir.d/client/{{ item.name }}.conf

--- a/tasks/register_client.yml
+++ b/tasks/register_client.yml
@@ -1,15 +1,11 @@
 ---
-- name: Register client {{ item.name }}
-  shell: >
-    echo
-    "configure add client "
-    "name={{ item.name }} "
-    "address={{ item.address }} "
-    "password={{ item.password }}" |
-    bconsole
-  args:
-    creates: "/etc/bareos/bareos-dir.d/client/{{ item.name }}.conf"
-  register: _bconsole_output
+- name: Create client {{ item.name }} config file
+  template:
+    src: bareos-dir/client/client.conf.j2
+    dest: /etc/bareos/bareos-dir.d/client/{{ item.name }}.conf
+    owner: bareos
+    group: bareos
+    mode: '0640'
   notify: Reload bareos server
 
 - name: Generate md5sum from password

--- a/templates/bareos-dir/client/client.conf.j2
+++ b/templates/bareos-dir/client/client.conf.j2
@@ -1,0 +1,12 @@
+# {{ ansible_managed }}
+Client {
+  Name = "{{ item.name }}"
+  Address = "{{ item.address }}"
+  Password = "{{ item.password }}"
+{% if item.description is defined %}
+  Description = {{ item.description }}
+{% endif %}
+{% if item.max_concurrent_jobs is defined %}
+  Maximum Concurrent Jobs = {{ item.max_concurrent_jobs }}
+{% endif %}
+}

--- a/templates/bareos-dir/job/BackupCatalog.conf.j2
+++ b/templates/bareos-dir/job/BackupCatalog.conf.j2
@@ -12,7 +12,7 @@ Job {
   RunBeforeJob = "{{ bareos_catalog_backup_script }} MyCatalog"
 
   # This deletes the copy of the catalog
-  RunAfterJob  = "/usr/lib/bareos/scripts/delete_catalog_backup"
+  RunAfterJob  = "/usr/lib/bareos/scripts/delete_catalog_backup MyCatalog"
 
   # This sends the bootstrap via mail for disaster recovery.
   # Should be sent to another system, please change recipient accordingly


### PR DESCRIPTION
- Register clients with a template instead of shell/bconsole
- Add missing handler notify to reload Bareos server when changing conf
- Specify which catalog to delete in Backupcatalog job, to avoid a warning (no change, the default MyCatalog was picked)