### PR TITLE
Remove Update client address step

### DIFF
--- a/tasks/register_client.yml
+++ b/tasks/register_client.yml
@@ -101,10 +101,3 @@
   when:
     - item.autostart | default(false)
     - _bareos_backup_job.changed
-
-- name: Update client address if changed
-  lineinfile:
-    path: /etc/bareos/bareos-dir.d/client/{{ item.name }}.conf
-    regexp: '^  Address = '
-    line: '  Address = {{ item.address }}'
-  notify: Reload bareos server


### PR DESCRIPTION
This step is not used anymore, since the address is automatically updated when generating the config from its template (https://github.com/mila-iqia/ansible-role-bareos/pull/40).