### PR TITLE
feat: Add parameters to configure concurrent reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ __Note:__ More options can be seen in `defaults/main.yml`
 - `bareos_director` - If you need to override backup director IP address on your client's /etc/hosts
 - `bareos_repo` - Defaults to Bareos Community Repository. Can be changed to use the Bareos Subscription Repository
 - `bareos_sd_max_concurrent_jobs` - [Optional] SD-level maximum concurrent jobs, defaults to 50
+- `bareos_sd_file_device_concurrent_read` - [Optional] SD-level specifies the maximum number of Jobs with the current Storage resource that can read concurrently
 - `bareos_catalog_backup_script` - You need to set it to `/usr/lib/bareos/scripts/make_catalog_backup` if using Bareos >=23
 ```
 bareos_director:
@@ -90,6 +91,7 @@ bareos_dir_storage:
     bareos_sd_ip: 10.0.0.1
     media_type: File2                   # optional, defaults to 'File'
     max_concurrent_jobs: 42             # optional, defaults to '50'
+    max_concurrent_read_jobs: 5         # optional
 ```
 `device` can also become `devices` if you have multiple devices :
 ```

--- a/templates/bareos-dir/storage/storage.conf.j2
+++ b/templates/bareos-dir/storage/storage.conf.j2
@@ -12,4 +12,7 @@ Storage {
   Device = {{ item.device }}
 {% endif %}
   Maximum Concurrent Jobs = {{ item.max_concurrent_jobs | default('50') }}
+{% if item.max_concurrent_read_jobs is defined %}
+  Maximum Concurrent Read Jobs = {{ item.max_concurrent_read_jobs }}
+{% endif %}
 }

--- a/templates/bareos-sd/storage/bareos-sd.conf.j2
+++ b/templates/bareos-sd/storage/bareos-sd.conf.j2
@@ -1,6 +1,9 @@
 Storage {
   Name = {{ inventory_hostname }}-sd
   Maximum Concurrent Jobs = {{ bareos_sd_max_concurrent_jobs | default('50') }}
+{% if bareos_sd_file_device_concurrent_read is defined %}
+  File Device Concurrent Read = {{ bareos_sd_file_device_concurrent_read }}
+{% endif %}
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,


### PR DESCRIPTION
This can be useful for migration and copy jobs, especially when multiple jobs have been interleaved within a single volume.