### PR TITLE
feat: Add support of multiplied devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ bareos_devices:
     mode: '0750'                        # default
     opts: ''                            # optional, for ansible.posix.mount
     state: 'mounted'                    # default, for ansible.posix.mount
+    count: 5                            # optional, number of multiplied devices
     media_type: File2                   # optional, defaults to 'File'
     max_concurrent_jobs: 42             # optional, defaults to '50'
 ```

--- a/templates/bareos-sd/device/device.conf.j2
+++ b/templates/bareos-sd/device/device.conf.j2
@@ -1,5 +1,9 @@
 # {{ ansible_managed }}
 Device {
+{% if item.count is defined %}
+  # Multiply this device Count times
+  Count = {{ item.count }}
+{% endif %}
   Name = "{{ item.name }}"
   Media Type = {{ item.media_type | default('File') }}
   Archive Device = {{ item.archive_device | default(item.arch_device) }}


### PR DESCRIPTION
The `Count (Sd->Device)` allows to multiply identical devices.