### PR TITLE
fix: Allow to define filesystem.opts

### DIFF
--- a/tasks/bareos_sd.yml
+++ b/tasks/bareos_sd.yml
@@ -31,6 +31,7 @@
         dev: "{{ item.block_device }}"
         force: false
         state: present
+        opts: "{{ item.opts | default(omit) }}"
       loop: "{{ bareos_devices }}"
       # Create file system only when block_device starts with '/dev/'
       when:


### PR DESCRIPTION
The user must be able to define additional parameters to format the block devices used by the storage daemon service.

Fixes #45