### PR TITLE
feat: Add support of Client Run Before/After Job to Jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ bareos_jobdefs:
     type: JOB_TYPE                      # optional, defaults to 'Backup'
     max_concurrent_jobs: 42             # optional, defaults to '50'
     allow_mixed_priority: 'yes'         # optional
+    client_run_before_job: "/etc/init.d/grafana-server stop"        # optional
+    client_run_after_job: "/etc/init.d/grafana-server start"        # optional
 ```
 
 `bareos_jobs`: List of jobs in following format:

--- a/templates/bareos-dir/jobdefs/jobdef.conf.j2
+++ b/templates/bareos-dir/jobdefs/jobdef.conf.j2
@@ -19,6 +19,12 @@ Keep the legacy defaults when the template is used to define JobDefs resources
 {% if item.client is defined %}
   Client = {{ item.client }}
 {% endif %}
+{% if item.client_run_after_job is defined %}
+  Client Run After Job = "{{ item.client_run_before_job }}"
+{% endif %}
+{% if item.client_run_before_job is defined %}
+  Client Run Before Job = "{{ item.client_run_before_job }}"
+{% endif %}
 {% if item.fileset is defined %}
   FileSet = "{{ item.fileset }}"
 {% endif %}

--- a/templates/bareos-dir/jobdefs/jobdef.conf.j2
+++ b/templates/bareos-dir/jobdefs/jobdef.conf.j2
@@ -20,7 +20,7 @@ Keep the legacy defaults when the template is used to define JobDefs resources
   Client = {{ item.client }}
 {% endif %}
 {% if item.client_run_after_job is defined %}
-  Client Run After Job = "{{ item.client_run_before_job }}"
+  Client Run After Job = "{{ item.client_run_after_job }}"
 {% endif %}
 {% if item.client_run_before_job is defined %}
   Client Run Before Job = "{{ item.client_run_before_job }}"


### PR DESCRIPTION
This is useful to run commands before or after backup jobs.
For example: stopping a service, backup a now released file, then start the service again.