### PR TITLE
fix: Use mkfs_opts instead of opts for devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ bareos_devices:
     block_device: /dev/mapper/backup    # optional
     fstype: 'ext4'                      # default
     mode: '0750'                        # default
+    mkfs_opts: ''                       # optional, options for mkfs
     opts: ''                            # optional, for ansible.posix.mount
     state: 'mounted'                    # default, for ansible.posix.mount
     count: 5                            # optional, number of multiplied devices

--- a/tasks/bareos_sd.yml
+++ b/tasks/bareos_sd.yml
@@ -31,7 +31,7 @@
         dev: "{{ item.block_device }}"
         force: false
         state: present
-        opts: "{{ item.opts | default(omit) }}"
+        opts: "{{ item.mkfs_opts | default(omit) }}"
       loop: "{{ bareos_devices }}"
       # Create file system only when block_device starts with '/dev/'
       when:


### PR DESCRIPTION
This fix the bug introduced in 6fa7eec where `bareos_devices.opts` was used to define mkfs options while it is already used to define mount options for the devices. Instead of `opts`, use `mkfs_opts`.