### PR TITLE
fix: Replace opts with mount_opts for devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ bareos_devices:
     fstype: 'ext4'                      # default
     mode: '0750'                        # default
     mkfs_opts: ''                       # optional, options for mkfs
-    opts: ''                            # optional, for ansible.posix.mount
+    mount_opts: ''                      # optional, for ansible.posix.mount
     state: 'mounted'                    # default, for ansible.posix.mount
     count: 5                            # optional, number of multiplied devices
     media_type: File2                   # optional, defaults to 'File'
@@ -125,6 +125,10 @@ bareos_devices:
 > [!WARNING]
 > The `bareos_devices[*].arch_device` is deprecated and replaced by
 > `bareos_devices[*].archive_device`.
+
+> [!WARNING]
+> The `bareos_devices[*].opts` is deprecated and replaced by
+> `bareos_devices[*].mount_opts`.
 
 `bareos_schedules`: List of schedules in following format:
 

--- a/tasks/bareos_sd.yml
+++ b/tasks/bareos_sd.yml
@@ -25,6 +25,15 @@
 - name: Configure Storage Daemon block devices
   when: bareos_devices is defined
   block:
+    - name: Check for deprecated bareos_devices[*].opts variables
+      failed_when: false
+      ansible.builtin.fail:
+        msg: "WARNING: Variable `bareos_devices[*].opts` is deprecated"
+      loop: "{{ bareos_devices }}"
+      when:
+        - item.opts is defined
+        - item.mount_opts is not defined
+
     - name: Create file systems
       community.general.filesystem:
         fstype: "{{ item.fstype | default('ext4') }}"
@@ -43,7 +52,7 @@
         path: "{{ item.archive_device | default(item.arch_device) }}"
         src: "{{ item.block_device }}"
         fstype: "{{ item.fstype | default('ext4') }}"
-        opts: "{{ item.opts | default(omit) }}"
+        opts: "{{ item.mount_opts | default(item.opts | default(omit)) }}"
         state: "{{ item.state | default('mounted') }}"
       loop: "{{ bareos_devices }}"
       when: item.block_device is defined


### PR DESCRIPTION
To avoid any confusion between mount and mkfs opts, rename option `opts` to `mount_opts`. Add a deprecation notice in the README and a test in the task to warn the user that `opts` is deprecated.