### PR TITLE
Add plugin bloc to fileset template

### DIFF
--- a/templates/bareos-dir/fileset/fileset.conf.j2
+++ b/templates/bareos-dir/fileset/fileset.conf.j2
@@ -18,6 +18,11 @@ FileSet {
     }
 {% endfor %}
 {% endif %}
+{% if item.plugin is defined %}
+    Plugin = "{{ item.plugin.name }}"
+             ":module_name={{ item.plugin.module_name }}"
+             ":mycnf={{ item.plugin.mycnf }}"
+{% endif %}
 {% if item.include_files is defined %}
 {% for include_file in item.include_files %}
     File = {{ include_file }}

--- a/templates/myself.conf.j2
+++ b/templates/myself.conf.j2
@@ -5,4 +5,10 @@ Client {
 {% if item.max_job_bandwidth is defined %}
   Maximum Bandwidth Per Job = {{ item.max_job_bandwidth }}
 {% endif %}
+{% if item.plugin_directory is defined %}
+  Plugin Directory = {{ item.plugin_directory }}
+{% endif %}
+{% if item.plugin_names is defined %}
+  Plugin Names = {{ item.plugin_names }}
+{% endif %}
 }


### PR DESCRIPTION
This merge request updates the Bareos FileSet Jinja2 template to include support for defining plugin parameters (e.g. mariabackup) within a FileSet.
Previously, the template only handled Options, Include, and Exclude sections. With this change, users can now specify a plugin block directly from their Ansible variables.